### PR TITLE
Add key tagging support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
-target
-Cargo.lock
+# Rust
+/target/
+/Cargo.lock
+**/*.rs.bk
+
+# IDE
+/.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "redis_cluster_rs"
-version = "0.1.6"
-authors = ["Atsushi Koge <atuk721@gmail.com>"]
+version = "0.1.7"
+authors = ["Atsushi Koge <atuk721@gmail.com>", "hedgar2017 <hedgar2017@gmail.com>"]
 keywords = ["redis", "cluster", "database"]
 description = "Redis cluster driver for Rust."
 homepage = "https://github.com/atuk721/redis-cluster-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,7 +474,6 @@ fn slot_for_packed_command(cmd: &[u8]) -> Option<u16> {
             Some(tag) => tag,
             None => &args[1],
         };
-        println!("{:?}", String::from_utf8_lossy(key));
         Some(State::<XMODEM>::calculate(key) % SLOT_SIZE as u16)
     } else {
         None


### PR DESCRIPTION
Redis Cluster specification states that in order to use pipelining all the keys within the same pipeline must contain the substring called hashtag, which looks like this: `{<tag>}`.

[Redis Cluster Spec](https://redis.io/topics/cluster-spec)

My method `get_hashtag` does exactly this.
It fixed the issue where I was constantly getting `MOVED` error responses.